### PR TITLE
fix: libext broken in verific compatibility mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+on:
+  push:
+
+jobs:
+  build_and_test:
+    name: "Build and Test"
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04, macos-15]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      # No need to install dependencies — only Ninja and CMake are needed,
+      # slang CMakeLists.txt fetch the rest.
+      #
+      #    https://github.com/actions/runner-images
+      - name: Build
+        run: |
+          rm -rf ./build
+          mkdir -p ./build
+          cd ./build
+          cmake -G Ninja ..
+          ninja
+      - name: Test
+        run: |
+          cd ./build
+          ctest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(ALL_TESTS
   test_cli_define
   test_libmap
   test_timescales
+  test_no_list
 )
 
 foreach(test_name ${ALL_TESTS})

--- a/test/run_test
+++ b/test/run_test
@@ -21,10 +21,30 @@ assert len(unused & result) == 0
 HERE
 }
 
-$prunefl -f list.f --top top_module \
+rm -f $bindir/$test.cache.json
+
+input_file="-f list.f"
+if ! test -f list.f; then
+  input_file=test.v
+fi
+
+$prunefl $input_file --top top_module \
+  --verific-compat --ignore-unknown-modules\
   --output-flags-to $bindir/$test.flags.f \
-  --output $bindir/$test.f
+  --output $bindir/$test.f \
+  --cache-to $bindir/$test.cache.json
 
 verify_unused ./unused.txt $bindir/$test.flags.f
 
-$slang_hier -F $bindir/$test.flags.f --top top_module --compat all --timescale=1ns/1ns
+$slang_hier --single-unit -F $bindir/$test.flags.f --top top_module --compat all --timescale=1ns/1ns
+
+# test loading from cache
+$prunefl $input_file --top top_module \
+  --verific-compat --ignore-unknown-modules\
+  --output-flags-to $bindir/$test.flags.cached.f \
+  --output $bindir/$test.cached.f \
+  --cache-to $bindir/$test.cache.json
+
+# only difference should be that it points to .cached.f instead of .f
+cat $bindir/$test.flags.cached.f | sed 's/.cached.f/.f/' | cmp $bindir/$test.flags.f - 
+cmp $bindir/$test.f $bindir/$test.cached.f

--- a/test/test_no_list/test.v
+++ b/test/test_no_list/test.v
@@ -1,0 +1,11 @@
+module top_module
+#(
+    parameter DEC_WIDTH = 8,
+    parameter ENC_WIDTH = 3
+)
+(
+    input  wire [ENC_WIDTH-1:0] in_enc_nnn,
+    output wire [DEC_WIDTH-1:0] out_dec_nnn
+);
+  assign out_dec_nnn = DEC_WIDTH'(1'b1 << in_enc_nnn);
+endmodule


### PR DESCRIPTION
- fix completely broken `+libext+` printing in verific compatibility mode
- add no-list test to CI
- update run_test to also test caching, and to use verific compatibility mode
- add ci
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix `+libext+` printing in Verific compatibility mode and enhance CI with new tests and caching support.
> 
>   - **Bug Fix**:
>     - Fix `+libext+` printing in Verific compatibility mode in `write_output_flags()` in `driver.cc`.
>   - **CI Enhancements**:
>     - Add `test.yml` for CI with build and test jobs on `ubuntu-24.04` and `macos-15`.
>     - Add `test_no_list` to `CMakeLists.txt`.
>     - Update `run_test` to test caching and use Verific compatibility mode.
>   - **Tests**:
>     - Add `test_no_list/test.v` for testing without a list file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2Fprunefl&utm_source=github&utm_medium=referral)<sup> for c9d5cf2e2b88c44ca9508cf008b3d0c57312ae58. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->