### PR TITLE
Use the shared release and CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,267 +4,44 @@ on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
+    inputs:
+      draft:
+        description: Publish a draft release and leave the `latest` tag alone.
+        type: boolean
+        default: false
 
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
-    name: Build anylinux amd64 tarball (musl)
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: true
-
-      - name: Build in Alpine container
-        run: |
-          docker run --rm \
-            -v "${{ github.workspace }}:/src" \
-            -w /src \
-            --platform linux/amd64 \
-            alpine:3.21 sh -c '
-              set -ex
-              apk add --no-cache \
-                build-base cmake ninja python3 git patchelf
-              git config --global --add safe.directory /src
-              git submodule foreach --recursive git config --global --add safe.directory \$toplevel/\$sm_path
-              mkdir -p build
-              cd build
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
-              ninja
-              mkdir -p /tmp/install/usr/local/bin /tmp/install/usr/local/lib
-              cp prunefl /tmp/install/usr/local/bin/
-
-              # Bundle shared library dependencies and set RPATHs
-              STAGE=/tmp/install/usr/local
-              for f in "$STAGE"/bin/*; do
-                [ -f "$f" ] || continue
-                ldd "$f" 2>/dev/null | awk "/=>/ {print \$3}" | while read -r lib; do
-                  [ -f "$lib" ] || continue
-                  base=$(basename "$lib")
-                  case "$base" in ld-musl-*|libc.musl-*) continue ;; esac
-                  [ -f "$STAGE/lib/$base" ] || cp "$lib" "$STAGE/lib/$base"
-                done
-                patchelf --set-rpath "\$ORIGIN/../lib" "$f"
-              done
-              for f in "$STAGE"/lib/*.so*; do
-                [ -f "$f" ] && patchelf --set-rpath "\$ORIGIN" "$f" 2>/dev/null || true
-              done
-
-              cd /tmp/install
-              tar czf /src/prunefl-anylinux-amd64.tar.gz .
-            '
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: prunefl-anylinux-amd64
-          path: prunefl-anylinux-amd64.tar.gz
-
-  build-manylinux:
-    runs-on: ubuntu-latest
-    name: Build manylinux2014 amd64 tarball (glibc 2.17+)
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: true
-
-      - name: Build in CentOS 7 container
-        run: |
-          docker run --rm \
-            -v "${{ github.workspace }}:/src" \
-            -w /src \
-            --platform linux/amd64 \
-            centos:7 bash -c '
-              set -ex
-
-              sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-              sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
-              sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-
-              yum install -y centos-release-scl epel-release
-              sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-              sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
-              sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-
-              yum install -y devtoolset-11-gcc-c++ make git curl python3 patchelf
-
-              curl -L https://github.com/Kitware/CMake/releases/download/v3.31.4/cmake-3.31.4-linux-x86_64.tar.gz | tar -xzC /opt
-              export PATH=/opt/cmake-3.31.4-linux-x86_64/bin:$PATH
-
-              # Install ninja from pre-built binary
-              curl -L https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip -o /tmp/ninja.zip
-              cd /tmp && python3 -c "import zipfile; zipfile.ZipFile(\"ninja.zip\").extractall()" && chmod +x ninja && mv ninja /usr/local/bin/
-              cd /src
-
-              source /opt/rh/devtoolset-11/enable
-              git config --global --add safe.directory /src
-              git submodule foreach --recursive git config --global --add safe.directory \$toplevel/\$sm_path
-
-              mkdir -p build
-              cd build
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
-              ninja
-              mkdir -p /tmp/install/usr/local/bin /tmp/install/usr/local/lib
-              cp prunefl /tmp/install/usr/local/bin/
-
-              STAGE=/tmp/install/usr/local
-              for f in "$STAGE"/bin/*; do
-                [ -f "$f" ] || continue
-                ldd "$f" 2>/dev/null | awk "/=>/ {print \$3}" | while read -r lib; do
-                  [ -f "$lib" ] || continue
-                  base=$(basename "$lib")
-                  case "$base" in ld-linux*|libc.so*|libdl*|libpthread*|librt*|libm.so*) continue ;; esac
-                  [ -f "$STAGE/lib/$base" ] || cp "$lib" "$STAGE/lib/$base"
-                done
-                patchelf --set-rpath "\$ORIGIN/../lib" "$f"
-              done
-              for f in "$STAGE"/lib/*.so*; do
-                [ -f "$f" ] && patchelf --set-rpath "\$ORIGIN" "$f" 2>/dev/null || true
-              done
-
-              cd /tmp/install
-              tar czf /src/prunefl-manylinux2014-amd64.tar.gz .
-            '
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: prunefl-manylinux2014-amd64
-          path: prunefl-manylinux2014-amd64.tar.gz
-
-  build-macos:
-    runs-on: macos-15
-    name: Build macOS arm64 tarball
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: true
-
-      - name: Install dependencies
-        run: |
-          brew install cmake ninja
-
-      - name: Build and package tarball
-        run: |
-          set -ex
-          mkdir -p build
-          cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
-          ninja
-          mkdir -p /tmp/install/usr/local/bin /tmp/install/usr/local/lib
-          cp prunefl /tmp/install/usr/local/bin/
-
-          STAGE=/tmp/install/usr/local
-
-          # Bundle non-system shared library dependencies
-          for f in "$STAGE"/bin/*; do
-            [ -f "$f" ] || continue
-            otool -L "$f" 2>/dev/null | awk 'NR>1 {print $1}' | while read -r lib; do
-              [ -f "$lib" ] || continue
-              base=$(basename "$lib")
-              case "$base" in libSystem*|libc++*|libobjc*) continue ;; esac
-              case "$lib" in /usr/lib/*|/System/*) continue ;; esac
-              [ -f "$STAGE/lib/$base" ] || cp "$lib" "$STAGE/lib/$base"
-            done
-          done
-
-          # Fix install names
-          for f in "$STAGE"/bin/*; do
-            [ -f "$f" ] || continue
-            install_name_tool -add_rpath "@executable_path/../lib" "$f" 2>/dev/null || true
-            for lib in "$STAGE"/lib/*.dylib; do
-              [ -f "$lib" ] || continue
-              base=$(basename "$lib")
-              install_name_tool -change "$(otool -L "$f" | grep "$base" | awk '{print $1}')" "@rpath/$base" "$f" 2>/dev/null || true
-            done
-          done
-          for f in "$STAGE"/lib/*.dylib; do
-            [ -f "$f" ] || continue
-            install_name_tool -id "@rpath/$(basename "$f")" "$f" 2>/dev/null || true
-          done
-
-          cd /tmp/install
-          tar czf "${{ github.workspace }}/prunefl-macos-arm64.tar.gz" .
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: prunefl-macos-arm64
-          path: prunefl-macos-arm64.tar.gz
-
   release:
-    runs-on: ubuntu-latest
-    needs: [build-linux, build-manylinux, build-macos]
-    name: Create GitHub releases
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          merge-multiple: true
-
-      - name: Generate release notes
-        id: meta
-        run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          FULL_SHA=$(git rev-parse HEAD)
-          DATE=$(date -u +%Y-%m-%d)
-          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
-          echo "date=$DATE" >> "$GITHUB_OUTPUT"
-          REPO_URL="${{ github.server_url }}/${{ github.repository }}"
-          printf '%s\n' \
-            "Automated build from \`main\` @ [\`${SHORT_SHA}\`](${REPO_URL}/commit/${FULL_SHA})" \
-            "" \
-            "**Built:** ${DATE}" \
-            "" \
-            "### Assets" \
-            "| File | Platform |" \
-            "|------|----------|" \
-            "| \`prunefl-anylinux-amd64.tar.gz\` | Linux x86-64 (musl, statically portable) |" \
-            "| \`prunefl-manylinux2014-amd64.tar.gz\` | Linux x86-64 (manylinux2014, glibc 2.17+) |" \
-            "| \`prunefl-macos-arm64.tar.gz\` | macOS Apple Silicon |" \
-            "" \
-            "### Installation" \
-            "\`\`\`bash" \
-            "sudo tar xzf prunefl-<platform>.tar.gz -C /" \
-            "\`\`\`" \
-            > release_notes.md
-
-      - name: Create permanent release
-        run: |
-          TAG="build-${{ steps.meta.outputs.date }}-${{ steps.meta.outputs.short_sha }}"
-          gh release create "$TAG" \
-            prunefl-anylinux-amd64.tar.gz \
-            prunefl-manylinux2014-amd64.tar.gz \
-            prunefl-macos-arm64.tar.gz \
-            --target "${{ github.sha }}" \
-            --title "Build ${{ steps.meta.outputs.date }} (${{ steps.meta.outputs.short_sha }})" \
-            --notes-file release_notes.md
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update latest release
-        run: |
-          git tag -f latest HEAD
-          git push -f origin latest
-          gh release delete latest --yes 2>/dev/null || true
-          gh release create latest \
-            prunefl-anylinux-amd64.tar.gz \
-            prunefl-manylinux2014-amd64.tar.gz \
-            prunefl-macos-arm64.tar.gz \
-            --target "${{ github.sha }}" \
-            --title "Latest Build (${{ steps.meta.outputs.date }})" \
-            --notes-file release_notes.md \
-            --prerelease
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: Silimate/actions/.github/workflows/native-tarball-release.yml@v1
+    permissions:
+      contents: write
+    with:
+      product: prunefl
+      # Only publish from main; pull requests build and smoke-test but release nothing
+      publish: ${{ github.event_name != 'pull_request' }}
+      draft: ${{ inputs.draft || false }}
+      with-ninja: true
+      # python3 drives misc/file2utf8z.py, which generates version.cc
+      alpine-packages: python3
+      centos-packages: python3
+      macos-packages: cmake ninja
+      build-script: |
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -S . -B build
+        cmake --build build -j"$NPROC"
+        cp build/prunefl "$STAGE/bin/"
+      smoke-test: |
+        # Extract to a throwaway prefix so the binary can only resolve its
+        # libraries through the RPATHs the bundling step set, exactly as a user
+        # would after unpacking the archive
+        rm -rf /tmp/smoke && mkdir -p /tmp/smoke
+        tar xzf "$TARBALL" -C /tmp/smoke
+        /tmp/smoke/usr/local/bin/prunefl --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,31 +1,19 @@
 name: Build and run tests
+
 on:
   push:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build_and_test:
-    name: "Build and Test"
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [ubuntu-24.04, macos-15]
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      # No need to install dependencies — only Ninja and CMake are needed,
-      # slang CMakeLists.txt fetch the rest.
-      #
-      #    https://github.com/actions/runner-images
-      - name: Build
-        run: |
-          rm -rf ./build
-          mkdir -p ./build
-          cd ./build
-          cmake -G Ninja ..
-          ninja
-      - name: Test
-        run: |
-          cd ./build
-          ctest
+  build-and-test:
+    uses: Silimate/actions/.github/workflows/cpp-cmake-ci.yml@v1
+    with:
+      # No dependency install: the runners already have Ninja and CMake, and
+      # slang's CMakeLists fetches the rest.
+      runners: >-
+        [{"name":"Ubuntu 24.04","family":"linux","runner":"ubuntu-24.04","arch":"x86_64"},
+         {"name":"macOS 15","family":"macos","runner":"macos-15","arch":"arm64"}]
+      cmake-generator: Ninja


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled three-platform release and the CMake test matrix with calls into the new [Silimate/actions](https://github.com/Silimate/actions) reusable workflows: 283 lines removed.
- `release.yml` 271 lines down to 38, `test.yml` 32 down to 20.

## Behaviour changes

- macOS bundling is now the same fixed-point implementation used across the org, and it re-signs after `install_name_tool` rewrites load paths. The previous version copied dylibs but never re-signed, which leaves arm64 binaries that macOS refuses to run.
- Ninja still comes from the upstream GitHub release on CentOS 7 rather than EPEL (which is archived alongside CentOS 7), but that is now the shared `with-ninja` input rather than an inline `curl` plus a Python one-liner to unzip.
- New smoke test unpacks each tarball to a throwaway prefix and runs `prunefl --version`.
- Pull requests build and smoke-test all three platforms without publishing.
- `ctest` now runs with `--output-on-failure`.

## Test plan

- [x] This PR's own run builds anylinux, manylinux2014 and macOS and passes the smoke test on each
- [x] `test.yml` passes on ubuntu-24.04 and macos-15
- [x] Compare `tar tzf` of the produced artifacts against the current `latest` release assets

Made with [Cursor](https://cursor.com)